### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,4 +1,6 @@
 name: Lint and Test
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/pedramktb/go-tagerr/security/code-scanning/1](https://github.com/pedramktb/go-tagerr/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow (`actions/checkout`, `actions/setup-go`, and `arduino/setup-task`), the workflow likely only needs read access to the repository contents. Therefore, we will set `contents: read` as the permission.

The `permissions` block will be added directly under the `name` field to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
